### PR TITLE
update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
 # Global Owners: These are brigadecore org maintainers + maintainers of this repo
-* @brigadecore/maintainers @brigadecore/docs-portuguese-maintainers
+* @brigadecore/maintainers @jorgearteiro @lucasjesuss


### PR DESCRIPTION
The `docs-portuguese-maintainers` team no longer exists.

It had only two members.

I've been auditing membership in the org in order to preserve secrets if we soon start to add some private repos, so these individuals were downgraded to "outside collaborators." They retain their privileged access to this one repo, but the `docs-portuguese-maintainers` team no longer had any members and was thus deleted.

Since the `docs-portuguese-maintainers` team no longer exists, this PR explicitly names the two outside collaborators who are authorized to review PRs to this repo.